### PR TITLE
Test fixes for 04.trace.t

### DIFF
--- a/t/04.trace.t
+++ b/t/04.trace.t
@@ -328,7 +328,7 @@ TestApp->config->{"Plugin::ErrorCatcher"}{enable} = 1;
     _has_value_for_key( 'BODY', 'long_text', 'kangarookangarookangarookangarookangaroo...[truncated]', $ec_msg);
     _has_value_for_key('QUERY', 'fruit',     'bananabananabananabananabananabananabana...[truncated]', $ec_msg);
     _has_value_for_key('QUERY', 'integer',   69, $ec_msg);
-    _has_value_for_key('QUERY', 'evil',      'two\nlines', $ec_msg);
+    _has_value_for_key('QUERY', 'evil',      'two\r\nlines', $ec_msg);
 }
 
 # helper methods for RT-72781 testing


### PR DESCRIPTION
Hello!

Attached are two patches for your consideration:

1.) Catayst::Plugin::ErrorCatcher HEAD fails a test on my system.  The last test in 04.trace.t, "'evil' has value 'two\nlines' in QUERY section", fails because HTTP::Request::Common::POST converts the \n to \r\n.  Included is a simple patch that fixes that test.

2.)  This is not a failing test, but when _has_param_section() is called with a BODY type, it was printing the test name as "QUERY params block exists".

All tests pass with Catalyst 5.90007. Unfortunately, Catalyst >=5.90008 has a bug that causes all the BODY tests to fail, which I've reported to RT.

Thank you for writing this module. I'm looking forward to using this in my application; I think it will come in really handy!

Cheers,
Fitz Elliott
